### PR TITLE
[PROPOSAL]Serializers can send content if image is missing

### DIFF
--- a/app/serializers/recipes/index_serializer.rb
+++ b/app/serializers/recipes/index_serializer.rb
@@ -4,12 +4,12 @@ class Recipes::IndexSerializer < ActiveModel::Serializer
   attributes :id, :title, :ingredients, :directions, :image
 
   def image
-    if object.image.attached?
-      if Rails.env.test?
-        rails_blob_url(object.image)
-      else
-        object.image.service_url(expires_in: 1.hour, disposition: 'inline')
-      end
+    return nil unless object.image.attached?
+    
+    if Rails.env.test?
+      rails_blob_url(object.image)
+    else
+      object.image.service_url(expires_in: 1.hour, disposition: 'inline')
     end
   end
 end

--- a/app/serializers/recipes/index_serializer.rb
+++ b/app/serializers/recipes/index_serializer.rb
@@ -4,10 +4,12 @@ class Recipes::IndexSerializer < ActiveModel::Serializer
   attributes :id, :title, :ingredients, :directions, :image
 
   def image
-    if Rails.env.test?
-      rails_blob_url(object.image)
-    else
-      object.image.service_url(expires_in: 1.hour, disposition: 'inline')
+    if object.image.attached?
+      if Rails.env.test?
+        rails_blob_url(object.image)
+      else
+        object.image.service_url(expires_in: 1.hour, disposition: 'inline')
+      end
     end
   end
 end

--- a/app/serializers/recipes/show_serializer.rb
+++ b/app/serializers/recipes/show_serializer.rb
@@ -4,12 +4,12 @@ class Recipes::ShowSerializer < ActiveModel::Serializer
   attributes :id, :title, :ingredients, :directions, :user_name, :user_id, :image
 
   def image
-    if object.image.attached?
-      if Rails.env.test?
-        rails_blob_url(object.image)
-      else
-        object.image.service_url(expires_in: 1.hour, disposition: 'inline')
-      end
+    return nil unless object.image.attached?
+
+    if Rails.env.test?
+      rails_blob_url(object.image)
+    else
+      object.image.service_url(expires_in: 1.hour, disposition: 'inline')
     end
   end
 

--- a/app/serializers/recipes/show_serializer.rb
+++ b/app/serializers/recipes/show_serializer.rb
@@ -4,10 +4,12 @@ class Recipes::ShowSerializer < ActiveModel::Serializer
   attributes :id, :title, :ingredients, :directions, :user_name, :user_id, :image
 
   def image
-    if Rails.env.test?
-      rails_blob_url(object.image)
-    else
-      object.image.service_url(expires_in: 1.hour, disposition: 'inline')
+    if object.image.attached?
+      if Rails.env.test?
+        rails_blob_url(object.image)
+      else
+        object.image.service_url(expires_in: 1.hour, disposition: 'inline')
+      end
     end
   end
 


### PR DESCRIPTION
[PT-link](https://www.pivotaltracker.com/story/show/169800400)

## PR content
A condition is added to `index` and `show` serializers which checks whether an image is attached.
If not, the recipe content is returned without an image.